### PR TITLE
[#342] Add Deprecation for fields w/ `-amount-in-cents` suffix

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -1,3 +1,5 @@
+require_relative 'lib/custom_markdown_renderer'
+
 # Markdown
 set :markdown_engine, :redcarpet
 set :markdown,
@@ -6,8 +8,8 @@ set :markdown,
     disable_indented_code_blocks: true,
     prettify: true,
     tables: true,
-    with_toc_data: true,
-    no_intra_emphasis: true
+    no_intra_emphasis: true,
+    renderer: CustomMarkdownRenderer.new(with_toc_data: true)
 
 # Assets
 set :css_dir, 'stylesheets'
@@ -19,6 +21,7 @@ set :fonts_dir, 'fonts'
 activate :syntax
 ready do
   require './lib/multilang.rb'
+  require './lib/helper.rb'
 end
 
 activate :sprockets

--- a/lib/custom_markdown_renderer.rb
+++ b/lib/custom_markdown_renderer.rb
@@ -1,0 +1,8 @@
+require 'middleman-core/renderers/redcarpet'
+
+class CustomMarkdownRenderer < Middleman::Renderers::MiddlemanRedcarpetHTML
+  def preprocess(document)
+    document = super(document) if defined?(super)
+    ERB.new(document).result(binding)
+  end
+end

--- a/lib/helper.rb
+++ b/lib/helper.rb
@@ -1,0 +1,15 @@
+require "pathname"
+
+class Helper
+  class << self
+    def render_shared(path)
+      File.open(shared_path.join(path), "r:UTF-8", &:read)
+    end
+
+    private
+
+    def shared_path
+      Pathname.new(File.expand_path('../source/includes/shared/', __dir__))
+    end
+  end
+end

--- a/source/includes/_oauth.md
+++ b/source/includes/_oauth.md
@@ -271,6 +271,7 @@ Content-Type: application/vnd.api+json; charset=utf-8
       "state": "not_renewing",
       "period": "annual"
       "currency": "EUR",
+      "monthly-amount": 1000,
       "monthly-amount-in-cents": 1000,
       "inserted-at": "2017-04-08T10:55:31.000000Z",
       "updated-at": "2017-05-01T10:55:31.000000Z",
@@ -302,9 +303,11 @@ Content-Type: application/vnd.api+json; charset=utf-8
       "attributes": {
         "state" : "published",
         "name": "Gold plan",
-        "monthly-amount-in-cents" : 2000,
-        "annual-amount-in-cents" : 12000,
         "currency" : "EUR",
+        "monthly-amount" : 2000,
+        "monthly-amount-in-cents" : 2000,
+        "annual-amount" : 12000,
+        "annual-amount-in-cents" : 12000,
         "benefits" : "foo bar baz",
         "ask-for-shiping-address" : false,
         "goal-enabled" : false,
@@ -349,8 +352,9 @@ Attribute | Description
 --------- | -----------
 state | guest / in_trial / active / not_renewing
 period | monthly / annual — the period of the contract of the user
-currency | EUR / USD
-monthly-amount-in-cents | monthly amount of the associated plan (users don't pay in states in_trial and guest)
+currency | currency for `*-amount`-field(s). Represented by 3 uppercase letters, e.g: `EUR`, `USD`, `SEK`,…
+monthly-amount | monthly amount of the associated plan (users don’t pay in states in_trial and guest)
+monthly-amount-in-cents | **DEPRECATED** Use `monthly-amount` instead.
 inserted-at | datetime of the creation of the subscription
 updated-at | datetime when the subscription was updated the last time on our system
 cancelled-at | datetime of the cancellation / null
@@ -364,9 +368,11 @@ Attribute | Description
 --------- | -----------
 state | published / archived
 name | name of the plan
-monthly-amount-in-cents | the amount a user with a monthly contract has to pay per month
-annual-amount-in-cents | the amount a user with an annual contract has to pay per year
-currency | EUR / USD
+currency | currency for `*-amount`-field(s). Represented by 3 uppercase letters, e.g: `EUR`, `USD`, `SEK`,…
+monthly-amount | the amount a user with a monthly contract has to pay per month
+monthly-amount-in-cents | **DEPRECATED** Use `monthly-amount` instead.
+annual-amount | the amount a user with an annual contract has to pay per year
+annual-amount-in-cents | **DEPRECATED** Use `annual-amount` instead.
 benefits | the benefits of this plan / null
 ask-for-shipping-address | boolean if we ask the user for her shipping address after she subscribed
 goal-enabled | boolean if this plan has a goal of a certain amount of subscriptions

--- a/source/includes/_oauth.md
+++ b/source/includes/_oauth.md
@@ -348,38 +348,7 @@ If the user has no subscription, or it has expired, the data attribute of the re
 read
 
 ### Subscription attributes
-Attribute | Description
---------- | -----------
-state | guest / in_trial / active / not_renewing
-period | monthly / annual — the period of the contract of the user
-currency | currency for `*-amount`-field(s). Represented by 3 uppercase letters, e.g: `EUR`, `USD`, `SEK`,…
-monthly-amount | monthly amount of the associated plan (users don’t pay in states in_trial and guest)
-monthly-amount-in-cents | **DEPRECATED** Use `monthly-amount` instead.
-inserted-at | datetime of the creation of the subscription
-updated-at | datetime when the subscription was updated the last time on our system
-cancelled-at | datetime of the cancellation / null
-trial-ends-at | datetime when the subscription's trial period will end or has ended / null
-active-from | datetime when the subscription was paid for the first time/ null
-expires-at | datetime when the subscription will expire / null
-rss-feed-url | if you use our podcast features, this is the rss-feed url with authentication for the subscriber
+<%= Helper.render_shared("_subscription_attributes.md") %>
 
 ### Plan attributes
-Attribute | Description
---------- | -----------
-state | published / archived
-name | name of the plan
-currency | currency for `*-amount`-field(s). Represented by 3 uppercase letters, e.g: `EUR`, `USD`, `SEK`,…
-monthly-amount | the amount a user with a monthly contract has to pay per month
-monthly-amount-in-cents | **DEPRECATED** Use `monthly-amount` instead.
-annual-amount | the amount a user with an annual contract has to pay per year
-annual-amount-in-cents | **DEPRECATED** Use `annual-amount` instead.
-benefits | the benefits of this plan / null
-ask-for-shipping-address | boolean if we ask the user for her shipping address after she subscribed
-goal-enabled | boolean if this plan has a goal of a certain amount of subscriptions
-subscriptions-goal | integer how many subscription should be reached if goal is enabled / null
-countdown-enabled | boolean if a countdown for this plan is enabled
-countdown-ends-at | datetime when the countdown will end if it is enabled / null
-hidden | boolean if the plan is hidden
-image-url | plan image url / null
-inserted-at | datetime of the creation of the plan
-updated-at | datetime when the plan was updated the last time on our system
+<%= Helper.render_shared("_plan_attributes.md") %>

--- a/source/includes/_plans.md
+++ b/source/includes/_plans.md
@@ -19,9 +19,11 @@ Content-Type: application/vnd.api+json; charset=utf-8
       "attributes": {
         "state" : "published",
         "name": "Gold plan",
-        "monthly-amount-in-cents" : 2000,
-        "annual-amount-in-cents" : 12000,
         "currency" : "EUR",
+        "monthly-amount" : 2000,
+        "monthly-amount-in-cents" : 2000,
+        "annual-amount" : 12000,
+        "annual-amount-in-cents" : 12000,
         "benefits" : "foo bar baz",
         "ask-for-shiping-address" : false,
         "goal-enabled" : false,
@@ -46,11 +48,13 @@ Returns an array with all plans of the publication.
 ### Attributes
 Attribute | Description
 --------- | -----------
-state | draft / published / archived
+state | published / archived
 name | name of the plan
-monthly-amount-in-cents | the amount a user with a monthly contract has to pay per month
-annual-amount-in-cents | the amount a user with an annual contract has to pay per year
-currency | EUR / USD
+currency | currency for `*-amount`-field(s). Represented by 3 uppercase letters, e.g: `EUR`, `USD`, `SEK`,…
+monthly-amount | the amount a user with a monthly contract has to pay per month
+monthly-amount-in-cents | **DEPRECATED** Use `monthly-amount` instead.
+annual-amount | the amount a user with an annual contract has to pay per year
+annual-amount-in-cents | **DEPRECATED** Use `annual-amount` instead.
 benefits | the benefits of this plan / null
 ask-for-shipping-address | boolean if we ask the user for her shipping address after she subscribed
 goal-enabled | boolean if this plan has a goal of a certain amount of subscriptions

--- a/source/includes/_plans.md
+++ b/source/includes/_plans.md
@@ -46,22 +46,4 @@ Content-Type: application/vnd.api+json; charset=utf-8
 Returns an array with all plans of the publication.
 
 ### Attributes
-Attribute | Description
---------- | -----------
-state | published / archived
-name | name of the plan
-currency | currency for `*-amount`-field(s). Represented by 3 uppercase letters, e.g: `EUR`, `USD`, `SEK`,…
-monthly-amount | the amount a user with a monthly contract has to pay per month
-monthly-amount-in-cents | **DEPRECATED** Use `monthly-amount` instead.
-annual-amount | the amount a user with an annual contract has to pay per year
-annual-amount-in-cents | **DEPRECATED** Use `annual-amount` instead.
-benefits | the benefits of this plan / null
-ask-for-shipping-address | boolean if we ask the user for her shipping address after she subscribed
-goal-enabled | boolean if this plan has a goal of a certain amount of subscriptions
-subscriptions-goal | integer how many subscription should be reached if goal is enabled / null
-countdown-enabled | boolean if a countdown for this plan is enabled
-countdown-ends-at | datetime when the countdown will end if it is enabled / null
-hidden | boolean if the plan is hidden
-image-url | plan image url / null
-inserted-at | datetime of the creation of the plan
-updated-at | datetime when the plan was updated the last time on our system
+<%= Helper.render_shared("_plan_attributes.md") %>

--- a/source/includes/_publication.md
+++ b/source/includes/_publication.md
@@ -22,6 +22,7 @@ Content-Type: application/vnd.api+json; charset=utf-8
       "paying-members-count": 7,
       "trial-members-count": 2,
       "guest-members-count": 1,
+      "monthly-amount": 14223,
       "monthly-amount-in-cents": 14223,
       "editor-name": "Foo Bear",
       "trial-period-activated": true,
@@ -49,7 +50,8 @@ members-count | the members count of the publication
 paying-members-count | the count of paying members of the publication
 trial-members-count | the count of trial members of the publication
 guest-members-count | the count of guest members of the publication
-monthly-amount-in-cents | the sum of the membership fees, the publication earns in a month
+monthly-amount | the sum of the membership fees, the publication earns in a month
+monthly-amount-in-cents | **DEPRECATED** Use `monthly-amount` instead.
 editor-name | the name of the publisher as shown on the Steady Page
 trial-period-activated | boolean if trial memberships are enabled for the publication
 public | boolean if the publication has been made public

--- a/source/includes/_subscriptions.md
+++ b/source/includes/_subscriptions.md
@@ -188,7 +188,7 @@ Attribute | Description
 --------- | -----------
 state | not_renewing
 period | monthly / annual — the period of the contract of the user
-currency | currency for all `*-amount-base-unit`-fields. Represented with 3 uppercase letters, e.g: `EUR`, `USD`, `SEK`,…
+currency | currency for all `*-amount`-fields. Represented with 3 uppercase letters, e.g: `EUR`, `USD`, `SEK`,…
 monthly-amount | monthly amount of the associated plan (users don't pay in states in_trial and guest)
 monthly-amount-in-cents | **DEPRECATED** Use `monthly-amount` instead.
 inserted-at | datetime of the creation of the subscription

--- a/source/includes/_subscriptions.md
+++ b/source/includes/_subscriptions.md
@@ -188,7 +188,7 @@ Attribute | Description
 --------- | -----------
 state | not_renewing
 period | monthly / annual — the period of the contract of the user
-currency | currency for all `*-amount`-fields. Represented with 3 uppercase letters, e.g: `EUR`, `USD`, `SEK`,…
+currency | EUR / USD / SEK
 monthly-amount | monthly amount of the associated plan (users don't pay in states in_trial and guest)
 monthly-amount-in-cents | **DEPRECATED** Use `monthly-amount` instead.
 inserted-at | datetime of the creation of the subscription

--- a/source/includes/_subscriptions.md
+++ b/source/includes/_subscriptions.md
@@ -91,20 +91,7 @@ Content-Type: application/vnd.api+json; charset=utf-8
 Returns an array with all current subscriptions of the publication.
 
 ### Attributes
-Attribute | Description
---------- | -----------
-state | guest / in_trial / active / not_renewing
-period | monthly / annual — the period of the contract of the user
-currency | currency for `*-amount`-field(s). Represented by 3 uppercase letters, e.g: `EUR`, `USD`, `SEK`,…
-monthly-amount | monthly amount of the associated plan (users don’t pay in states in_trial and guest)
-monthly-amount-in-cents | **DEPRECATED** Use `monthly-amount` instead.
-inserted-at | datetime of the creation of the subscription
-updated-at | datetime when the subscription was updated the last time on our system
-cancelled-at | datetime of the cancellation / null
-trial-ends-at | datetime when the subscription's trial period will end or has ended / null
-active-from | datetime when the subscription was paid for the first time/ null
-expires-at | datetime when the subscription will expire / null
-rss-feed-url | if you use our podcast features, this is the rss-feed url with authentication for the subscriber
+<%= Helper.render_shared("_subscription_attributes.md") %>
 
 ## POST /subscriptions/:subscription_id/cancel
 ```http

--- a/source/includes/_subscriptions.md
+++ b/source/includes/_subscriptions.md
@@ -20,6 +20,7 @@ Content-Type: application/vnd.api+json; charset=utf-8
         "state": "not_renewing",
         "period": "annual"
         "currency": "EUR",
+        "monthly-amount": 1000,
         "monthly-amount-in-cents": 1000,
         "inserted-at": "2017-04-08T10:55:31.000000Z",
         "updated-at": "2017-05-01T10:55:31.000000Z",
@@ -53,9 +54,11 @@ Content-Type: application/vnd.api+json; charset=utf-8
       "attributes": {
         "state" : "published",
         "name": "Gold plan",
-        "monthly-amount-in-cents" : 2000,
-        "annual-amount-in-cents" : 12000,
         "currency" : "EUR",
+        "monthly-amount" : 2000,
+        "monthly-amount-in-cents" : 2000,
+        "annual-amount" : 12000,
+        "annual-amount-in-cents" : 12000,
         "benefits" : "foo bar baz",
         "ask-for-shiping-address" : false,
         "goal-enabled" : false,
@@ -92,8 +95,9 @@ Attribute | Description
 --------- | -----------
 state | guest / in_trial / active / not_renewing
 period | monthly / annual — the period of the contract of the user
-currency | EUR / USD
-monthly-amount-in-cents | monthly amount of the associated plan (users don't pay in states in_trial and guest)
+currency | currency for `*-amount`-field(s). Represented by 3 uppercase letters, e.g: `EUR`, `USD`, `SEK`,…
+monthly-amount | monthly amount of the associated plan (users don’t pay in states in_trial and guest)
+monthly-amount-in-cents | **DEPRECATED** Use `monthly-amount` instead.
 inserted-at | datetime of the creation of the subscription
 updated-at | datetime when the subscription was updated the last time on our system
 cancelled-at | datetime of the cancellation / null
@@ -122,6 +126,7 @@ Content-Type: application/vnd.api+json; charset=utf-8
       "state": "not_renewing",
       "period": "annual"
       "currency": "EUR",
+      "monthly-amount": 1000,
       "monthly-amount-in-cents": 1000,
       "inserted-at": "2017-04-08T10:55:31.000000Z",
       "updated-at": "2017-05-01T10:55:31.000000Z",
@@ -152,9 +157,11 @@ Content-Type: application/vnd.api+json; charset=utf-8
         "attributes": {
           "state" : "published",
           "name": "Gold plan",
-          "monthly-amount-in-cents" : 2000,
-          "annual-amount-in-cents" : 12000,
           "currency" : "EUR",
+          "monthly-amount" : 2000,
+          "monthly-amount-in-cents" : 2000,
+          "annual-amount" : 12000,
+          "annual-amount-in-cents" : 12000,
           "benefits" : "foo bar baz",
           "ask-for-shiping-address" : false,
           "goal-enabled" : false,
@@ -194,8 +201,9 @@ Attribute | Description
 --------- | -----------
 state | not_renewing
 period | monthly / annual — the period of the contract of the user
-currency | EUR / USD
-monthly-amount-in-cents | monthly amount of the associated plan (users don't pay in states in_trial and guest)
+currency | currency for all `*-amount-base-unit`-fields. Represented with 3 uppercase letters, e.g: `EUR`, `USD`, `SEK`,…
+monthly-amount | monthly amount of the associated plan (users don't pay in states in_trial and guest)
+monthly-amount-in-cents | **DEPRECATED** Use `monthly-amount` instead.
 inserted-at | datetime of the creation of the subscription
 updated-at | datetime when the subscription was updated the last time on our system
 cancelled-at | datetime of the cancellation / null

--- a/source/includes/shared/_plan_attributes.md
+++ b/source/includes/shared/_plan_attributes.md
@@ -2,7 +2,7 @@ Attribute | Description
 --------- | -----------
 state | published / archived
 name | name of the plan
-currency | currency for `*-amount`-field(s). Represented by 3 uppercase letters, e.g: `EUR`, `USD`, `SEK`,…
+currency | EUR / USD / SEK
 monthly-amount | the amount a user with a monthly contract has to pay per month
 monthly-amount-in-cents | **DEPRECATED** Use `monthly-amount` instead.
 annual-amount | the amount a user with an annual contract has to pay per year

--- a/source/includes/shared/_plan_attributes.md
+++ b/source/includes/shared/_plan_attributes.md
@@ -1,0 +1,19 @@
+Attribute | Description
+--------- | -----------
+state | published / archived
+name | name of the plan
+currency | currency for `*-amount`-field(s). Represented by 3 uppercase letters, e.g: `EUR`, `USD`, `SEK`,…
+monthly-amount | the amount a user with a monthly contract has to pay per month
+monthly-amount-in-cents | **DEPRECATED** Use `monthly-amount` instead.
+annual-amount | the amount a user with an annual contract has to pay per year
+annual-amount-in-cents | **DEPRECATED** Use `annual-amount` instead.
+benefits | the benefits of this plan / null
+ask-for-shipping-address | boolean if we ask the user for her shipping address after she subscribed
+goal-enabled | boolean if this plan has a goal of a certain amount of subscriptions
+subscriptions-goal | integer how many subscription should be reached if goal is enabled / null
+countdown-enabled | boolean if a countdown for this plan is enabled
+countdown-ends-at | datetime when the countdown will end if it is enabled / null
+hidden | boolean if the plan is hidden
+image-url | plan image url / null
+inserted-at | datetime of the creation of the plan
+updated-at | datetime when the plan was updated the last time on our system

--- a/source/includes/shared/_subscription_attributes.md
+++ b/source/includes/shared/_subscription_attributes.md
@@ -2,7 +2,7 @@ Attribute | Description
 --------- | -----------
 state | guest / in_trial / active / not_renewing
 period | monthly / annual — the period of the contract of the user
-currency | currency for `*-amount`-field(s). Represented by 3 uppercase letters, e.g: `EUR`, `USD`, `SEK`,…
+currency | EUR / USD / SEK
 monthly-amount | monthly amount of the associated plan (users don’t pay in states in_trial and guest)
 monthly-amount-in-cents | **DEPRECATED** Use `monthly-amount` instead.
 inserted-at | datetime of the creation of the subscription

--- a/source/includes/shared/_subscription_attributes.md
+++ b/source/includes/shared/_subscription_attributes.md
@@ -1,0 +1,14 @@
+Attribute | Description
+--------- | -----------
+state | guest / in_trial / active / not_renewing
+period | monthly / annual — the period of the contract of the user
+currency | currency for `*-amount`-field(s). Represented by 3 uppercase letters, e.g: `EUR`, `USD`, `SEK`,…
+monthly-amount | monthly amount of the associated plan (users don’t pay in states in_trial and guest)
+monthly-amount-in-cents | **DEPRECATED** Use `monthly-amount` instead.
+inserted-at | datetime of the creation of the subscription
+updated-at | datetime when the subscription was updated the last time on our system
+cancelled-at | datetime of the cancellation / null
+trial-ends-at | datetime when the subscription's trial period will end or has ended / null
+active-from | datetime when the subscription was paid for the first time/ null
+expires-at | datetime when the subscription will expire / null
+rss-feed-url | if you use our podcast features, this is the rss-feed url with authentication for the subscriber


### PR DESCRIPTION
**Trello-Ticket**: https://trello.com/c/6KTnFxAl/342-fix-api-documentation

- Removes invalid `draft`-state from Plan attributes
- Adds missing `*-amount`-fields to `OAuth -> Current subscription`, `GET /publication`
- Adds the DEPRECATION warnings for all `*-amount-in-cents`-fields

**Proposal**
Adds a custom Markdown Renderer which enables us to embed ruby in our documentation Markdown-files. That could be useful for re-using parts of the documentation or if we want to create the JSON payloads more dynamically.